### PR TITLE
Allow msgpack 1.0 which fixes the Ruby 2.4 Integer changes.

### DIFF
--- a/simple_secrets.gemspec
+++ b/simple_secrets.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   if RUBY_PLATFORM == 'java'
-    spec.add_dependency "msgpack-jruby", "~> 1.4.0"
+    spec.add_dependency "msgpack-jruby", ">= 1.4.0"
   else
-    spec.add_dependency "msgpack", "~> 0.7.1"
+    spec.add_dependency "msgpack", ">= 0.7.1"
   end
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Ruby 2.4 unified integers:

https://blog.heroku.com/ruby-2-4-features-hashes-integers-rounding#unified-integers

However this breaks simple-secrets from running on ruby 2.4 currently
because of the version lock in place.